### PR TITLE
Allowed wildcard nodemon peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linkemon",
   "description": "Wrapper script around nodemon that will automatically watch all linked modules",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "Mario Casciaro"
   },
@@ -15,7 +15,7 @@
   },
   "preferGlobal": true,
   "peerDependencies": {
-    "nodemon": "^1.18.4"
+    "nodemon": "*"
   },
   "keywords": [
     "nodemon",


### PR DESCRIPTION
I noticed:
1. `linkemon` is not depedent on the specific version of `nodemon` as `linkemon` passes all arguments to `nodemon` itself.
2. the `nodemon` cli args necessary for `linkemon` to function properly is unchanged between major versions.

Hence:
I changed the `nodemon` peer dependency version to be a wildcard (`*`) as `linkemon` should allow version independence of `nodemon`